### PR TITLE
feat(window): allow modal to be moved across screens

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -97,7 +97,6 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import ClickOutside from 'vue-click-outside';
 import VueSlider from 'vue-slider-component';
 import Dropdown from '@/components/Dropdown.vue';
 import Checkbox from '@/components/Checkbox.vue';
@@ -127,10 +126,7 @@ const MENU_SIZE = {
     VueSlider,
     Checkbox,
     Dropdown,
-  },
-  directives: {
-    ClickOutside,
-  },
+  }
 })
 export default class App extends Vue {
   /** UI */

--- a/src/background.ts
+++ b/src/background.ts
@@ -42,7 +42,8 @@ const wins: BrowserWindow[] = [];
 const createWindow = async (
   onReadyCb: (w: BrowserWindow) => Promise<void> = async () => {},
 ) => {
-let width = 0;
+  // calculate the longest width and height to span over the entire workspace
+  let width = 0;
   let height = 0;
   for (const display of screen.getAllDisplays()) {
     width = Math.max(display.bounds.x + display.size.width, height);


### PR DESCRIPTION
Fixes: https://github.com/belvederef/visual-snow-relief-overlay/issues/21

Made a small change to help out a friend who's using this. Since the app creates a window for every screen you could not move the modal beyond screen boundaries which got in the way of working.

This change makes use of the largerThanScreen option to span the entire workspace and thus allow the modal to be moved.

The modal currently is always placed at the center due to App.vue. Happy for ideas to make this smarter.